### PR TITLE
Sato/#84 attendance store process

### DIFF
--- a/app/Http/Controllers/AttendanceController.php
+++ b/app/Http/Controllers/AttendanceController.php
@@ -70,8 +70,7 @@ class AttendanceController extends Controller
         }
 
         /* 日付型に変換する */
-        $date = explode("-", $query);
-        $dt = Carbon::create($date[0], $date[1], $date[2]);
+        $dt = Carbon::parse($query);
         /* 未来だったら弾く */
         if ($dt->gt(Carbon::today())) {
             abort(403);

--- a/app/Http/Controllers/AttendanceController.php
+++ b/app/Http/Controllers/AttendanceController.php
@@ -56,7 +56,7 @@ class AttendanceController extends Controller
     /**
      * show attendance create page.
      *
-     * @return \Illuminate\Contracts\Support\Renderable
+     * @return Illuminate\Http\RedirectResponse
      */
     public function create(Request $request)
     {
@@ -78,5 +78,16 @@ class AttendanceController extends Controller
         } else {
             return redirect()->route('attendances.index');
         }
+    }
+
+    /**
+     * Store attendance data.
+     *
+     * @return Illuminate\Http\RedirectResponse
+     */
+    public function store(Request $request)
+    {
+
+        return redirect()->route('attendances.index');
     }
 }

--- a/app/Http/Controllers/AttendanceController.php
+++ b/app/Http/Controllers/AttendanceController.php
@@ -71,7 +71,7 @@ class AttendanceController extends Controller
 
         /* 日付型に変換する */
         $date = explode("-", $query);
-        $dt = Carbon::create($date[0], $date[1], $date[2], 0, 0, 0);
+        $dt = Carbon::create($date[0], $date[1], $date[2]);
         /* 未来だったら弾く */
         if ($dt->gt(Carbon::today())) {
             abort(403);
@@ -95,7 +95,7 @@ class AttendanceController extends Controller
     public function store(AttendanceRequest $request)
     {
         /* 未来だったら弾く */
-        $date = Carbon::createFromFormat('Y-m-d', $request->date);
+        $date = Carbon::parse($request->date);
         if ($date->gt(Carbon::today())) {
             abort(403);
         }

--- a/app/Http/Controllers/AttendanceController.php
+++ b/app/Http/Controllers/AttendanceController.php
@@ -56,7 +56,7 @@ class AttendanceController extends Controller
     /**
      * show attendance create page.
      *
-     * @return Illuminate\Http\RedirectResponse
+     * @return \Illuminate\Contracts\Support\Renderable|Illuminate\Http\RedirectResponse
      */
     public function create(Request $request)
     {
@@ -68,9 +68,10 @@ class AttendanceController extends Controller
             /* 日付型に変換する */
             $date = explode("-", $query);
             $dt = Carbon::create($date[0], $date[1], $date[2], 0, 0, 0);
-            /* 今日の日付だった場合のみビューに渡す */
-            if ($dt->eq(Carbon::today())) {
-                return view('attendances/create');
+            /* DBにレコードが存在しない日付の場合のみ登録画面に遷移する */
+            if (!Attendance::where('user_id', Auth::user()->id)
+            ->where('date', $dt)->exists()) {
+                return view('attendances/create', compact('dt'));
             } else {
             /* 勤怠表示画面に戻す */
                 return redirect()->route('attendances.index');

--- a/app/Http/Controllers/AttendanceController.php
+++ b/app/Http/Controllers/AttendanceController.php
@@ -95,7 +95,7 @@ class AttendanceController extends Controller
     public function store(AttendanceRequest $request)
     {
         /* 未来だったら弾く */
-        $date = Carbon::createFromFormat('Y-m-d H:i:s', $request->date);
+        $date = Carbon::createFromFormat('Y-m-d', $request->date);
         if ($date->gt(Carbon::today())) {
             abort(403);
         }

--- a/app/Http/Controllers/AttendanceController.php
+++ b/app/Http/Controllers/AttendanceController.php
@@ -100,11 +100,6 @@ class AttendanceController extends Controller
             abort(403);
         }
 
-        /* 終了時刻が開始時刻よりも前だったら弾く */
-        if (strcmp($request->end_time, $request->start_time) <= 0) {
-            abort(403);
-        }
-
         /* DBに勤務登録があった場合は弾く */
         if (Attendance::where('user_id', Auth::user()->id)
         ->where('date', $request->date)->exists()) {

--- a/app/Http/Requests/AttendanceRequest.php
+++ b/app/Http/Requests/AttendanceRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AttendanceRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'date' => 'required|date',
+            'absence' => 'string',
+            'start_time' => 'string',
+            'end_time' => 'string',
+        ];
+    }
+}

--- a/app/Http/Requests/AttendanceRequest.php
+++ b/app/Http/Requests/AttendanceRequest.php
@@ -27,7 +27,7 @@ class AttendanceRequest extends FormRequest
             'date' => 'required|date',
             'absence' => 'string',
             'start_time' => 'string',
-            'end_time' => 'string',
+            'end_time' => 'string|after:start_time',
         ];
     }
 }

--- a/resources/lang/ja/validation.php
+++ b/resources/lang/ja/validation.php
@@ -140,6 +140,9 @@ return [
         '属性名' => [
             'ルール名' => 'カスタムメッセージ',
         ],
+        'end_time' => [
+            'after' => ':attributeには、:dateより後の時刻を指定してください。',
+        ],
     ],
 
     /*
@@ -164,6 +167,8 @@ return [
         'birthdate_year' => '誕生年',
         'birthdate_month' => '誕生月',
         'birthdate_day' => '誕生日',
+        'start_time' => '開始時刻',
+        'end_time' => '終了時刻',
     ],
 
 ];

--- a/resources/views/attendances/create.blade.php
+++ b/resources/views/attendances/create.blade.php
@@ -3,6 +3,15 @@
 @section('content')
 <div class="container">
     <div class="row justify-content-center">
+        @if ($errors->any())
+            <div class="alert alert-danger">
+                @foreach ($errors->all() as $message)
+                    <ul>
+                        <li>{{ $message }}</li>
+                    </ul>
+                @endforeach
+            </div>
+        @endif
         <div class="col-md-8">
             <div class="card">
                 <form method="POST" action="{{ route('attendances.store') }}">

--- a/resources/views/attendances/create.blade.php
+++ b/resources/views/attendances/create.blade.php
@@ -18,7 +18,7 @@
                                 <tr>
                                     <th class="text-start">日付</th>
                                     <td>
-                                        {{ $dt->isoFormat('Y年M月D日（ddd）') }}
+                                        {{ $dt->copy()->isoFormat('Y年M月D日（ddd）') }}
                                     </td>
                                 </tr>
                                 <tr>

--- a/resources/views/attendances/create.blade.php
+++ b/resources/views/attendances/create.blade.php
@@ -5,7 +5,7 @@
     <div class="row justify-content-center">
         <div class="col-md-8">
             <div class="card">
-                <form method="POST" action="">
+                <form method="POST" action="{{ route('attendances.store') }}">
                     @csrf
 
                     <div class="card-header">勤怠入力</div>

--- a/resources/views/attendances/create.blade.php
+++ b/resources/views/attendances/create.blade.php
@@ -44,12 +44,13 @@
                                 <tr>
                                     <th class="text-start"></th>
                                     <td>
-                                        <input type="checkbox" id="absence" name="absence">
+                                        <input type="checkbox" id="absence" name="absence" value="absence">
                                         <label for="absence">休業にする</label>
                                     </td>
                                 </tr>
                             </tbody>
                         </table>
+                        <input type="hidden" name="date" value="{{ $dt }}">
                     </div>
                     <div class="card-footer">
                         <button type="submit" class="btn btn-primary">

--- a/resources/views/attendances/create.blade.php
+++ b/resources/views/attendances/create.blade.php
@@ -12,11 +12,12 @@
                     <div class="card-body">
                         <table class="table table-borderless">
                             <tbody>
+                                @php
+                                    $date = \Carbon\Carbon::today();
+                                    $period = \Carbon\CarbonPeriod::create('09:00:00', '18:00:00')->minutes(30)->toArray();
+                                @endphp
                                 <tr>
                                     <th class="text-start">日付</th>
-                                    @php
-                                        $date = \Carbon\Carbon::today();
-                                    @endphp
                                     <td>
                                         {{ $date->isoFormat('Y年M月D日（ddd）') }}
                                     </td>
@@ -25,17 +26,9 @@
                                     <th class="text-start">開始時刻</th>
                                     <td>
                                         <select id="start_time" name="start_time">
-                                            <option value="13:00" selected>13:00</option>
-                                            <option value="13:30">13:30</option>
-                                            <option value="14:00">14:00</option>
-                                            <option value="14:30">14:30</option>
-                                            <option value="15:00">15:00</option>
-                                            <option value="15:30">15:30</option>
-                                            <option value="16:00">16:00</option>
-                                            <option value="16:30">16:30</option>
-                                            <option value="17:00">17:00</option>
-                                            <option value="17:30">17:30</option>
-                                            <option value="18:00">18:00</option>
+                                            @foreach ($period as $time)
+                                                <option value="{{ $time->format('H:i') }}" {{ $time->eq(\Carbon\Carbon::create('13:00:00')) ? 'selected' : '' }}>{{ $time->format('H:i') }}</option>
+                                            @endforeach
                                         </select>
                                     </td>
                                 </tr>
@@ -43,17 +36,9 @@
                                     <th class="text-start">終了時刻</th>
                                     <td>
                                         <select id="end_time" name="end_time">
-                                            <option value="13:00">13:00</option>
-                                            <option value="13:30">13:30</option>
-                                            <option value="14:00">14:00</option>
-                                            <option value="14:30">14:30</option>
-                                            <option value="15:00">15:00</option>
-                                            <option value="15:30">15:30</option>
-                                            <option value="16:00">16:00</option>
-                                            <option value="16:30">16:30</option>
-                                            <option value="17:00">17:00</option>
-                                            <option value="17:30">17:30</option>
-                                            <option value="18:00" selected>18:00</option>
+                                            @foreach ($period as $time)
+                                                <option value="{{ $time->format('H:i') }}" {{ $time->eq(\Carbon\Carbon::create('18:00:00')) ? 'selected' : '' }}>{{ $time->format('H:i') }}</option>
+                                            @endforeach
                                         </select>
                                     </td>
                                 </tr>

--- a/resources/views/attendances/create.blade.php
+++ b/resources/views/attendances/create.blade.php
@@ -13,13 +13,12 @@
                         <table class="table table-borderless">
                             <tbody>
                                 @php
-                                    $date = \Carbon\Carbon::today();
                                     $period = \Carbon\CarbonPeriod::create('09:00:00', '18:00:00')->minutes(30)->toArray();
                                 @endphp
                                 <tr>
                                     <th class="text-start">日付</th>
                                     <td>
-                                        {{ $date->isoFormat('Y年M月D日（ddd）') }}
+                                        {{ $dt->isoFormat('Y年M月D日（ddd）') }}
                                     </td>
                                 </tr>
                                 <tr>

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,3 +36,4 @@ Route::post('/user/update', [App\Http\Controllers\UserController::class, 'update
 Route::get('/attendances', [App\Http\Controllers\AttendanceController::class, 'index'])->name('attendances.index');
 /* attendance create page */
 Route::get('/attendances/add', [App\Http\Controllers\AttendanceController::class, 'create'])->name('attendances.create');
+Route::post('/attendances/add', [App\Http\Controllers\AttendanceController::class, 'store'])->name('attendances.store');


### PR DESCRIPTION
勤怠入力画面からDBへ登録する処理storeメソッドを実装しました。
登録がない日に勤怠情報を登録するメソッドとなります。
・すでに登録のある日付の場合は弾きます。
・未来の日付では登録できないです。
・終了時刻は開始時刻よりも前である必要があります。
・バリデーションしました。AttencandeRequest.phpです。
※createメソッドにも手を加えました。