### PR TITLE
Sato/#100 flash message store update reset db attendance

### DIFF
--- a/app/Http/Controllers/AttendanceController.php
+++ b/app/Http/Controllers/AttendanceController.php
@@ -221,7 +221,7 @@ class AttendanceController extends Controller
             /* DBに登録する */
             $attendance->save();
 
-            return redirect()->route('attendances.index')->with('message', '更新しました。');
+            return redirect()->route('attendances.index')->with('message', '変更しました。');
         }
 
         /* 取消ボタンが押された場合の処理 */
@@ -229,7 +229,7 @@ class AttendanceController extends Controller
             /* レコードを削除する */
             $attendance->delete();
 
-            return redirect()->route('attendances.index')->with('message', '削除しました。');
+            return redirect()->route('attendances.index')->with('message', '取消しました。');
         }
 
         /* 勤怠表示画面に戻す */

--- a/app/Http/Controllers/AttendanceController.php
+++ b/app/Http/Controllers/AttendanceController.php
@@ -135,7 +135,7 @@ class AttendanceController extends Controller
         $attendance->save();
 
         /* 勤怠表示画面に戻す */
-        return redirect()->route('attendances.index');
+        return redirect()->route('attendances.index')->with('message', '登録しました。');
     }
 
     /**
@@ -220,12 +220,16 @@ class AttendanceController extends Controller
 
             /* DBに登録する */
             $attendance->save();
+
+            return redirect()->route('attendances.index')->with('message', '更新しました。');
         }
 
         /* 取消ボタンが押された場合の処理 */
         if ($request->has('reset')) {
             /* レコードを削除する */
             $attendance->delete();
+
+            return redirect()->route('attendances.index')->with('message', '削除しました。');
         }
 
         /* 勤怠表示画面に戻す */

--- a/resources/views/attendances/edit.blade.php
+++ b/resources/views/attendances/edit.blade.php
@@ -78,7 +78,7 @@
                     </div>
                     <div class="card-footer d-flex justify-content-between">
                         <button type="submit" name="update" class="btn btn-primary">
-                            更新
+                            変更
                         </button>
                         <button type="submit" name="reset" class="btn btn-primary">
                             取消

--- a/resources/views/attendances/index.blade.php
+++ b/resources/views/attendances/index.blade.php
@@ -3,6 +3,11 @@
 @section('content')
 <div class="container">
     <div class="row justify-content-center">
+        @if (session('message'))
+            <div class="alert alert-success">
+                {{ session('message') }}
+            </div>
+        @endif
         <div class="col-md-10">
             <div class="card">
                 <div class="card-header">{{ $dt->year }}年{{ $dt->month }}月 の勤怠</div>


### PR DESCRIPTION
勤怠情報を登録・変更・取消した時にフラッシュメッセージを一覧画面に出すようにしました。
ボタンとメッセージの表現を統一して、変更・取消にしました。