### PR TITLE
Sato/#90 select time disabled jQuery

### DIFF
--- a/resources/views/attendances/create.blade.php
+++ b/resources/views/attendances/create.blade.php
@@ -39,7 +39,7 @@
                                 </tr>
                                 <th>状態</th>
                                 <td>
-                                    <select id="status" name="status"> 
+                                    <select id="status" name="status">
                                         <option value="" selected>--</option>
                                         <option value="full">出勤（全日）</option>
                                         <option value="half">出勤（半日）</option>
@@ -89,20 +89,16 @@
 
 @section('script')
 <script>
-let start_time = document.getElementById('start_time');
-let end_time = document.getElementById('end_time');
-let absence = document.getElementById('absence');
-
-function specifyTime() {
-    if (absence.checked) {
-        start_time.disabled = true;
-        end_time.disabled = true;
-    } else {
-        start_time.disabled = false;
-        end_time.disabled = false;
-    }
-}
-
-absence.addEventListener('change', specifyTime);
+$(() => {
+    $('#status').change(() => {
+        if ($('#status').val() == 'off') {
+            $('#start_time').prop('disabled', true);
+            $('#end_time').prop('disabled', true);
+        } else {
+            $('#start_time').prop('disabled', false);
+            $('#end_time').prop('disabled', false);
+        }
+    });
+});
 </script>
 @endsection

--- a/resources/views/attendances/create.blade.php
+++ b/resources/views/attendances/create.blade.php
@@ -89,16 +89,16 @@
 
 @section('script')
 <script>
-$(() => {
-    $('#status').change(() => {
-        if ($('#status').val() == 'off') {
-            $('#start_time').prop('disabled', true);
-            $('#end_time').prop('disabled', true);
-        } else {
-            $('#start_time').prop('disabled', false);
-            $('#end_time').prop('disabled', false);
-        }
-    });
+{
+$('#status').on('change', () => {
+    if ($('#status').val() === 'off') {
+        $('#start_time').prop('disabled', true);
+        $('#end_time').prop('disabled', true);
+    } else {
+        $('#start_time').prop('disabled', false);
+        $('#end_time').prop('disabled', false);
+    }
 });
+}
 </script>
 @endsection

--- a/resources/views/attendances/create.blade.php
+++ b/resources/views/attendances/create.blade.php
@@ -89,7 +89,6 @@
 
 @section('script')
 <script>
-{
 $('#status').on('change', () => {
     if ($('#status').val() === 'off') {
         $('#start_time').prop('disabled', true);
@@ -99,6 +98,5 @@ $('#status').on('change', () => {
         $('#end_time').prop('disabled', false);
     }
 });
-}
 </script>
 @endsection

--- a/resources/views/attendances/edit.blade.php
+++ b/resources/views/attendances/edit.blade.php
@@ -105,21 +105,21 @@
 
 @section('script')
 <script>
-$(() => {
-    if ($('#status').val() == 'off') {
-            $('#start_time').prop('disabled', true);
-            $('#end_time').prop('disabled', true);
-        }
+{
+if ($('#status').val() === 'off') {
+        $('#start_time').prop('disabled', true);
+        $('#end_time').prop('disabled', true);
+    }
 
-    $('#status').change(() => {
-        if ($('#status').val() == 'off') {
-            $('#start_time').prop('disabled', true);
-            $('#end_time').prop('disabled', true);
-        } else {
-            $('#start_time').prop('disabled', false);
-            $('#end_time').prop('disabled', false);
-        }
-    });
+$('#status').on('change', () => {
+    if ($('#status').val() === 'off') {
+        $('#start_time').prop('disabled', true);
+        $('#end_time').prop('disabled', true);
+    } else {
+        $('#start_time').prop('disabled', false);
+        $('#end_time').prop('disabled', false);
+    }
 });
+}
 </script>
 @endsection

--- a/resources/views/attendances/edit.blade.php
+++ b/resources/views/attendances/edit.blade.php
@@ -105,11 +105,10 @@
 
 @section('script')
 <script>
-{
 if ($('#status').val() === 'off') {
-        $('#start_time').prop('disabled', true);
-        $('#end_time').prop('disabled', true);
-    }
+    $('#start_time').prop('disabled', true);
+    $('#end_time').prop('disabled', true);
+}
 
 $('#status').on('change', () => {
     if ($('#status').val() === 'off') {
@@ -120,6 +119,5 @@ $('#status').on('change', () => {
         $('#end_time').prop('disabled', false);
     }
 });
-}
 </script>
 @endsection

--- a/resources/views/attendances/edit.blade.php
+++ b/resources/views/attendances/edit.blade.php
@@ -48,9 +48,9 @@
                                             'full'  => '出勤（全日）',
                                             'half'  => '出勤（半日）',
                                             'off'   => '休業',
-                                                ]                                         
+                                                ]
                                         @endphp
-                                        <select id="status" name="status"> 
+                                        <select id="status" name="status">
                                             @foreach ($select_items as $key => $value)
                                                 <option value="{{ $key }}" {{$key === $status ? 'selected' : ''}}>{{$value}}</option>
                                             @endforeach
@@ -105,20 +105,21 @@
 
 @section('script')
 <script>
-let start_time = document.getElementById('start_time');
-let end_time = document.getElementById('end_time');
-let absence = document.getElementById('absence');
+$(() => {
+    if ($('#status').val() == 'off') {
+            $('#start_time').prop('disabled', true);
+            $('#end_time').prop('disabled', true);
+        }
 
-function specifyTime() {
-    if (absence.checked) {
-        start_time.disabled = true;
-        end_time.disabled = true;
-    } else {
-        start_time.disabled = false;
-        end_time.disabled = false;
-    }
-}
-
-absence.addEventListener('change', specifyTime);
+    $('#status').change(() => {
+        if ($('#status').val() == 'off') {
+            $('#start_time').prop('disabled', true);
+            $('#end_time').prop('disabled', true);
+        } else {
+            $('#start_time').prop('disabled', false);
+            $('#end_time').prop('disabled', false);
+        }
+    });
+});
 </script>
 @endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -57,7 +57,7 @@
                             @endif
                         @else
                             <li class="nav-item dropdown">
-                               
+
                                 <a id="navbarDropdown" class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" v-pre>
                                     {{ Auth::user()->last_name ." ". Auth::user()->first_name }}
                                 </a>
@@ -91,5 +91,7 @@
             @yield('content')
         </main>
     </div>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
+    @yield('script')
 </body>
 </html>


### PR DESCRIPTION
勤怠登録と変更画面で「休業」を選んだ時、開始時刻と終了時刻が選択できないようにしました。
JavaScript を jQuery に変更しました。
app.blade.php で jQuery を外部から読み込むコードを入れました。問題があればお願いします。